### PR TITLE
Add updates from prod interrupt fix

### DIFF
--- a/kmod/aq_compat.h
+++ b/kmod/aq_compat.h
@@ -212,16 +212,24 @@ static inline void ether_addr_copy(u8 *dst, const u8 *src)
 	RHEL_RELEASE_CODE < RHEL_RELEASE_VERSION(7, 4)
 #define NETIF_F_GSO_PARTIAL 0
 #endif
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(4, 8, 0)) || \
-	(RHEL_RELEASE_CODE && (RHEL_RELEASE_CODE <= RHEL_RELEASE_VERSION(7, 4)))
-#define pci_irq_vector_compat(self, nr) \
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 8, 0)
+#if	!RHEL_RELEASE_CODE || (RHEL_RELEASE_CODE < RHEL_RELEASE_VERSION(7, 5))
+#ifdef CONFIG_PCI_MSI
+#define pci_irq_vector_compat(pdev, nr) \
 ( \
-	(self->pdev->msix_enabled) ? \
-		self->msix_entry[nr].vector \
+	(pdev->msix_enabled) ? \
+		((struct aq_nic_s *)pci_get_drvdata(pdev))->msix_entry[nr].vector \
 		: \
-		self->pdev->irq + nr \
+		pdev->irq + nr \
 )
-#endif
+#else
+#define pci_irq_vector(pdev, nr) \
+( \
+    pdev->irq \
+)
+#endif /* CONFIG_PCI_MSI */
+#endif /* !RHELL || RHEL < 7.5 */
+#endif /* < 4.8.0 */
 
 #if !IS_ENABLED(CONFIG_CRC_ITU_T)
 u16 crc_itu_t(u16 crc, const u8 *buffer, size_t len);

--- a/kmod/aq_nic.h
+++ b/kmod/aq_nic.h
@@ -46,6 +46,7 @@ struct aq_nic_cfg_s {
 	u32 rxds;		/* rx ring size, descriptors # */
 	u32 txds;		/* tx ring size, descriptors # */
 	u32 vecs;		/* allocated rx/tx vectors */
+	u32 num_irq_vecs;
 	u32 link_irq_vec;
 	u32 irq_type;
 	u32 itr;

--- a/kmod/aq_ptp.h
+++ b/kmod/aq_ptp.h
@@ -49,13 +49,8 @@ static inline unsigned int aq_ptp_ring_idx(const enum aq_tc_mode tc_mode)
 #if IS_REACHABLE(CONFIG_PTP_1588_CLOCK)
 
 /* Common functions */
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 7, 0)
-int aq_ptp_init(struct aq_nic_s *aq_nic, unsigned int idx_ptp_vec,
-		unsigned int idx_ext_vec, unsigned int ptp_vec, unsigned int gpio_vec);
-#else
 int aq_ptp_init(struct aq_nic_s *aq_nic, unsigned int idx_ptp_vec,
 		unsigned int idx_ext_vec);
-#endif
 
 void aq_ptp_unregister(struct aq_nic_s *aq_nic);
 void aq_ptp_free(struct aq_nic_s *aq_nic);
@@ -117,13 +112,8 @@ struct aq_ptp_s {
 };
 
 /* Common functions */
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 7, 0)
-static inline int aq_ptp_init(struct aq_nic_s *aq_nic, unsigned int idx_ptp_vec,
-		unsigned int idx_ext_vec, unsigned int ptp_vec, unsigned int gpio_vec)
-#else
 static inline int aq_ptp_init(struct aq_nic_s *aq_nic, unsigned int idx_ptp_vec,
 		unsigned int idx_ext_vec)
-#endif
 {
 	return 0;
 }

--- a/kmod/hw_atl/hw_atl_b0.c
+++ b/kmod/hw_atl/hw_atl_b0.c
@@ -655,7 +655,7 @@ static int hw_atl_b0_hw_init(struct aq_hw_s *self, u8 *mac_addr)
 	/* Interrupts */
 	hw_atl_reg_irq_glb_ctl_set(self,
 		aq_hw_atl_igcr_table_[aq_nic_cfg->irq_type]
-			[(aq_nic_cfg->link_irq_vec > 0) ?
+			[(aq_nic_cfg->num_irq_vecs > 0) ?
 				1 : 0]);
 
 	hw_atl_itr_irq_auto_masklsw_set(self, aq_nic_cfg->aq_hw_caps->irq_mask);

--- a/kmod/hw_atl2/hw_atl2.c
+++ b/kmod/hw_atl2/hw_atl2.c
@@ -729,7 +729,7 @@ static int hw_atl2_hw_init(struct aq_hw_s *self, u8 *mac_addr)
 	/* Interrupts */
 	hw_atl_reg_irq_glb_ctl_set(self,
 		aq_hw_atl2_igcr_table_[aq_nic_cfg->irq_type]
-			[(aq_nic_cfg->link_irq_vec > 0) ?
+			[(aq_nic_cfg->num_irq_vecs > 0) ?
 				1 : 0]);
 
 	hw_atl_itr_irq_auto_masklsw_set(self, aq_nic_cfg->aq_hw_caps->irq_mask);


### PR DESCRIPTION
- Fixes segmentation fault on driver unloading.
- Able to set gpio mode to input and trigger events.
- Disables PTP when not enough IRQ vectors available.